### PR TITLE
✨ Set concurrency rules for jobs

### DIFF
--- a/.github/workflows/codeql-analysis-javascript.yml
+++ b/.github/workflows/codeql-analysis-javascript.yml
@@ -2,6 +2,10 @@ name: 'CodeQL - Javascript'
 on:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: 'Analyze'

--- a/.github/workflows/codeql-analysis-jvm.yml
+++ b/.github/workflows/codeql-analysis-jvm.yml
@@ -2,6 +2,10 @@ name: 'CodeQL - Java'
 on:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: 'Analyze'

--- a/.github/workflows/docker-build-branch.yml
+++ b/.github/workflows/docker-build-branch.yml
@@ -6,6 +6,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: 'Branch Publish'

--- a/.github/workflows/docker-build-tag.yml
+++ b/.github/workflows/docker-build-tag.yml
@@ -6,6 +6,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: '${{ github.workflow }}'
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: 'Main Publish'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [ labeled, unlabeled, opened, reopened, synchronize ]
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: 'Check For Valid Label'

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -2,6 +2,11 @@ name: 'Semver Tag'
 on:
   pull_request:
     types: [ closed ]
+  workflow_call:
+
+concurrency:
+  group: '${{ github.workflow }}'
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -32,3 +37,13 @@ jobs:
           tag: ${{ steps.calculate.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           move_major_tag: true
+
+      - name: Post failure to Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.21.0
+        if: ${{ failure() }}
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "GitHub Action failure: ${{github.repository}}\nRun: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}\nOriginating PR: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -16,6 +16,10 @@ on:
         type: string
         default: '[ "14.x", "16.x" , "18.x" ]'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: 'Unit and Integration Tests'

--- a/.github/workflows/test-jvm.yml
+++ b/.github/workflows/test-jvm.yml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: 'Unit and Integration Tests'


### PR DESCRIPTION
Two types,
1) Cancel active job if another workflow needs to start i.e. test actions when the code changes
2) Queue jobs behind active jobs i.e. tagging and building docker images that need to finish if another workflow needs to start