### PR TITLE
⚡️HOCS-5511: Add Dependency caching, concurrency handling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,5 @@ updates:
     reviewers:
       - "UKHomeOffice/hocs-core"
     labels:
-      - "skip-release"
+      - "patch"
       - "dependencies"

--- a/.github/workflows/codeql-analysis-gradle.yml
+++ b/.github/workflows/codeql-analysis-gradle.yml
@@ -1,6 +1,10 @@
-name: 'CodeQL - Java'
+name: 'CodeQL - Gradle'
 on:
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   analyze:
@@ -20,19 +24,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+          cache: gradle
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
           languages: 'java'
 
-      - name: Run tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: wrapper
-          arguments: clean assemble --no-daemon
+      - name: Build jar
+        run: ./gradlew clean assemble --no-daemon
         env:
           PACKAGE_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
-      - name: Perform CodeQL Analysis
+      - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql-analysis-javascript.yml
+++ b/.github/workflows/codeql-analysis-javascript.yml
@@ -2,6 +2,10 @@ name: 'CodeQL - Javascript'
 on:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: 'Analyze'

--- a/.github/workflows/docker-build-branch-gradle.yml
+++ b/.github/workflows/docker-build-branch-gradle.yml
@@ -1,4 +1,4 @@
-name: 'Docker Build Branch'
+name: 'Docker Build Branch - Gradle'
 on:
   workflow_call:
     inputs:
@@ -6,11 +6,16 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     name: 'Branch Publish'
-    runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'smoketest') == true
+    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -26,7 +31,6 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        id: buildx
         uses: docker/setup-buildx-action@v2
 
       - name: Calculate metadata
@@ -37,13 +41,25 @@ jobs:
           tags: |
             type=raw,value=${{ github.event.pull_request.head.sha }}
 
+      - name: Use Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: gradle
+
+      - name: Build jar
+        run: ./gradlew clean assemble --no-daemon
+        env:
+          PACKAGE_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
       - name: Build container
         uses: docker/build-push-action@v3
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            PACKAGE_TOKEN=${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/docker-build-branch-npm.yml
+++ b/.github/workflows/docker-build-branch-npm.yml
@@ -1,0 +1,65 @@
+name: 'Docker Build Branch - npm'
+on:
+  workflow_call:
+    inputs:
+      images:
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: 'Branch Publish'
+    if: contains(github.event.pull_request.labels.*.name, 'smoketest') == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USER_NAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Calculate metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ inputs.images }}
+          tags: |
+            type=raw,value=${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm --loglevel warn ci --production=false --no-optional
+
+      - name: Build project
+        run: npm run build-prod
+
+      - name: Build container
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-tag-gradle.yml
+++ b/.github/workflows/docker-build-tag-gradle.yml
@@ -1,4 +1,4 @@
-name: 'Docker Build Tag'
+name: 'Docker Build Tag - Gradle'
 on:
   workflow_call:
     inputs:
@@ -6,13 +6,18 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: 'Main Publish'
-    runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'skip-release') == false
+    runs-on: ubuntu-latest
+
     steps:
       - name: Parse the SemVer label
         id: label
@@ -46,7 +51,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_to_highest: ${{ github.base_ref == 'main' }}
 
-
       - name: Calculate metadata
         id: meta
         uses: docker/metadata-action@v4
@@ -56,10 +60,24 @@ jobs:
             type=raw,value=${{steps.calculate.outputs.version}}
             type=raw,value=latest,enable=${{ github.base_ref == 'main' }}
 
+      - name: Use Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: gradle
+
+      - name: Build jar
+        run: ./gradlew clean assemble --no-daemon
+        env:
+          PACKAGE_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
       - name: Build container
         uses: docker/build-push-action@v3
         with:
           context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-build-tag-npm.yml
+++ b/.github/workflows/docker-build-tag-npm.yml
@@ -1,16 +1,18 @@
-name: 'Semver Tag'
+name: 'Docker Build Tag - npm'
 on:
-  pull_request:
-    types: [ closed ]
   workflow_call:
+    inputs:
+      images:
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:
-  tag:
-    name: 'Main Tag'
+  publish:
+    name: 'Main Publish'
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'skip-release') == false
@@ -24,6 +26,23 @@ jobs:
           labels: minor,major,patch
           mode: singular
 
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USER_NAME }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Calculate SemVer value
         id: calculate
         uses: UKHomeOffice/semver-calculate-action@v1
@@ -32,12 +51,33 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_to_highest: ${{ github.base_ref == 'main' }}
 
+      - name: Calculate metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ inputs.images }}
+          tags: |
+            type=raw,value=${{steps.calculate.outputs.version}}
+            type=raw,value=latest,enable=${{ github.base_ref == 'main' }}
+
+      - name: Build container
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            PACKAGE_TOKEN=${{secrets.GITHUB_TOKEN}}
+
       - name: Tag Repository
         uses: UKHomeOffice/semver-tag-action@v3
         with:
           tag: ${{ steps.calculate.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          move_major_tag: true
 
       - name: Post failure to Slack channel
         id: slack

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,20 +3,28 @@ on:
   pull_request:
     types: [ labeled, unlabeled, opened, reopened, synchronize ]
   workflow_call:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  check:
     name: 'Check For Valid Label'
     runs-on: ubuntu-latest
+
     steps:
-      - id: label
+      - name: Check label value
+        id: label
         uses: UKHomeOffice/match-label-action@v1
         with:
           labels: minor,major,patch,skip-release
           mode: singular
-      - uses: UKHomeOffice/semver-tag-action@v2
+
+      - name: Calculate SemVer value
         if: contains(steps.label.outputs.matchedLabels, 'skip-release') == false
+        uses: UKHomeOffice/semver-calculate-action@v1
         with:
           increment: ${{ steps.label.outputs.matchedLabels }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          default_use_head_tag: ${{ github.base_ref == 'main' }}
-          dry_run: true
+          default_to_highest: ${{ github.base_ref == 'main' }}

--- a/.github/workflows/test-gradle.yml
+++ b/.github/workflows/test-gradle.yml
@@ -1,4 +1,4 @@
-name: 'Test'
+name: 'Test - Gradle'
 on:
   workflow_call:
     inputs:
@@ -11,19 +11,16 @@ on:
       elastic:
         required: false
         type: string
-      node-version-matrix:
-        required: false
-        type: string
-        default: '[ "14.x", "16.x" , "18.x" ]'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     name: 'Unit and Integration Tests'
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: ${{ fromJson(inputs.node-version-matrix) }}
-      fail-fast: false
+
     steps:
       - name: Install OS dependencies
         if: ${{ inputs.dependencies != '' }}
@@ -34,11 +31,12 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Node
-        uses: actions/setup-node@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          distribution: 'temurin'
+          java-version: '17'
+          cache: gradle
 
       - name: Start infrastructure
         if:  ${{ inputs.components != '' }}
@@ -48,14 +46,7 @@ jobs:
           INCLUDE_ELASTIC: ${{ inputs.elastic || 'false' }}
         shell: bash
 
-      - name: Install npm dependencies
-        run: npm --loglevel warn ci --production=false --no-optional
-
-      - name: Build project
-        run: npm run build-prod
-
-      - name: Lint project
-        run: npm run lint
-
-      - name: Run tests
-        run: npm test
+      - name: Build jar
+        run: ./gradlew clean test --no-daemon
+        env:
+          PACKAGE_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/test-npm.yml
+++ b/.github/workflows/test-npm.yml
@@ -1,4 +1,4 @@
-name: 'Test'
+name: 'Test - npm'
 on:
   workflow_call:
     inputs:
@@ -11,11 +11,24 @@ on:
       elastic:
         required: false
         type: string
+      node-version-matrix:
+        required: false
+        type: string
+        default: '[ "16.x" , "18.x" ]'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
     name: 'Unit and Integration Tests'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ${{ fromJson(inputs.node-version-matrix) }}
+      fail-fast: false
+
     steps:
       - name: Install OS dependencies
         if: ${{ inputs.dependencies != '' }}
@@ -26,11 +39,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Java
-        uses: actions/setup-java@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          distribution: 'temurin'
-          java-version: '17'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Start infrastructure
         if:  ${{ inputs.components != '' }}
@@ -40,10 +53,14 @@ jobs:
           INCLUDE_ELASTIC: ${{ inputs.elastic || 'false' }}
         shell: bash
 
+      - name: Install npm dependencies
+        run: npm --loglevel warn ci --production=false --no-optional
+
+      - name: Build project
+        run: npm run build-prod
+
+      - name: Lint project
+        run: npm run lint
+
       - name: Run tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: wrapper
-          arguments: clean build --no-daemon
-        env:
-          PACKAGE_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ on:
 
 jobs:
   analyze:
-    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/codeql-analysis-javascript.yml@v1
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/codeql-analysis-javascript.yml@v2
 ```
 
-## codeql-analysis-jvm.yml
+## codeql-analysis-gradle.yml
 This is a [CodeQL](https://codeql.github.com/) static analysis action for jvm languages.
 This build can use the caching gradle actions over generic job that uses the `autobuild` step.
 Typically, this is run on a daily schedule and on changes to source code only, ignoring test code.
@@ -44,11 +44,11 @@ on:
 
 jobs:
   analyze:
-    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/codeql-analysis-jvm.yml@v1
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/codeql-analysis-gradle.yml@v2
 ```
 
-## docker-build-branch.yml
-A language agnostic job to build a docker image, tag it with the pull request head SHA and publish it to a repository.
+## docker-build-branch-gradle.yml
+A job to build a docker image that requires artifacts building with gradle, tag it with the pull request head SHA and publish it to a repository.
 To save docker repository spam this will only trigger if a label is added to the PR with the value of `smoketest`.
 Currently, this is arbitrarily limited to Quay. 
 
@@ -61,14 +61,34 @@ on:
 
 jobs:
   build:
-    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/docker-build-branch.yml@v1
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/docker-build-branch-gradle.yml@v2
     with:
       images: 'quay.io/ukhomeofficedigital/hocs-audit'
     secrets: inherit
 ```
 
-## docker-build-tag.yml
-A language agnostic job to build a docker image, tag it with a SemVer value incremented by a label (`major`, `minor`, `patch`) on the PR and publish it to a repository.
+## docker-build-branch-npm.yml
+A job to build a docker image that requires artifacts building with npm, tag it with the pull request head SHA and publish it to a repository.
+To save docker repository spam this will only trigger if a label is added to the PR with the value of `smoketest`.
+Currently, this is arbitrarily limited to Quay.
+
+### Example usage
+```yaml
+name: 'Docker Build Branch'
+on:
+  pull_request:
+    types: [ labeled, opened, reopened, synchronize ]
+
+jobs:
+  build:
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/docker-build-branch-npm.yml@v2
+    with:
+      images: 'quay.io/ukhomeofficedigital/hocs-audit'
+    secrets: inherit
+```
+
+## docker-build-tag-gradle.yml
+A language agnostic job to build a docker image that requires artifacts building with gradle, tag it with a SemVer value incremented by a label (`major`, `minor`, `patch`) on the PR and publish it to a repository.
 It will also tag the commit SHA with the same SemVer Tag.
 To save docker repository spam this will not trigger if a label is added to the PR with the value of `skip-release`.
 Currently, this is arbitrarily limited to Quay. 
@@ -82,15 +102,32 @@ on:
 
 jobs:
   build:
-    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/docker-build-tag.yml@v1
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/docker-build-tag-gradle.yml@v2
     with:
       images: 'quay.io/ukhomeofficedigital/hocs-audit'
     secrets: inherit
 ```
 
-## dockerfile-lint.yml
-This is only run on PRs within this repository, and is used to validate a docker-compose file on PR. 
+## docker-build-tag-npm.yml
+A language agnostic job to build a docker image that requires artifacts building with npm, tag it with a SemVer value incremented by a label (`major`, `minor`, `patch`) on the PR and publish it to a repository.
+It will also tag the commit SHA with the same SemVer Tag.
+To save docker repository spam this will not trigger if a label is added to the PR with the value of `skip-release`.
+Currently, this is arbitrarily limited to Quay.
 
+### Example usage
+```yaml
+name: 'Docker Build Tag'
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  build:
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/docker-build-tag-npm.yml@v2
+    with:
+      images: 'quay.io/ukhomeofficedigital/hocs-audit'
+    secrets: inherit
+```
 
 ## pr-check.yml
 This action is used to ensure one of the required labels is set on a PR in order for jobs that run after the PR is merged not to fail.
@@ -109,12 +146,24 @@ jobs:
 ```
 
 ## semver-tag.yml
-This is only run locally to tag the commit SHA with a SemVer value incremented by a label (`major`, `minor`, `patch`).
+This run locally or remotely to tag the commit SHA with a SemVer value incremented by a label (`major`, `minor`, `patch`).
 This will not trigger if a label is added to the PR with the value of `skip-release`.
 This will also walk a 'GitHub action' style major version tag along with the SemVer value.
 e.g. `v1` with tag `1.2.3`.
 
-## test-javascript.yml
+### Example usage
+```yaml
+name: 'SemVer Tag'
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  check:
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/semver-tag.yml@v2
+```
+
+## test-npm.yml
 This action will run `npm run lint` and `npm test` on a repository after building it with `npm ci`.
 It will run tests in parallel against 3 versions of node; `14`, `16`, `18`.
 Optionally this action will install dependencies required to run tests.
@@ -130,14 +179,14 @@ on:
 
 jobs:
   test:
-    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/test-javascript.yml@v1
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/test-npm.yml@v2
     with:
       components: 'localstack postgres'
       elastic: 'true'
       dependencies: 'libreoffice curl'
 ```
 
-## test-jvm.yml
+## test-gradle.yml
 This action will run a gradle build on a repository.
 It currently runs on Java 17.
 Optionally this action will also install dependencies required to run tests.
@@ -153,7 +202,7 @@ on:
 
 jobs:
   test:
-    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/test-jvm.yml@v1
+    uses: UKHomeOffice/hocs-ci-infrastructure/.github/workflows/test-gradle.yml@v2
     with:
       components: 'localstack postgres'
       elastic: 'true'


### PR DESCRIPTION
New pipelines to include per workflow npm and gradle dependency caching and concurrency handling of tasks. Most tasks will cancel if a new one of the same type starts within a branch. The exception to this is docker-build-tag-* jobs which will queue as they need to coordinate access to the tags. The breaking change is to require dockerfiles to build their packages outside the dockerfile which is a return the previous behaviour, but saves 10-15 mins now that we build AMD64 and ARM64 architectures using buildx and qemu.